### PR TITLE
Introducing Quaternion based rotations

### DIFF
--- a/transform.hpp
+++ b/transform.hpp
@@ -23,16 +23,11 @@ namespace OpenGLEngine {
         glm::mat4 positionMatrix = glm::mat4(1.0);
         positionMatrix = glm::translate(positionMatrix, position);
 
-        glm::mat4 rotationXMatrix = glm::mat4(1.0);
-        rotationXMatrix = glm::rotate(rotationXMatrix, rotation.x, glm::vec3(1.0, 0.0, 0.0));
+		glm::vec3 radianRotation = glm::radians(mRotation);	// Convert degree rotation angles to radians.
 
-        glm::mat4 rotationYMatrix = glm::mat4(1.0);
-        rotationYMatrix = glm::rotate(rotationYMatrix, rotation.y, glm::vec3(0.0, 1.0, 0.0));
+		glm::quat quaternion	 = glm::quat(radianRotation); // Generate a quaternion from radian rotation.
 
-        glm::mat4 rotationZMatrix = glm::mat4(1.0);
-        rotationZMatrix = glm::rotate(rotationZMatrix, rotation.z, glm::vec3(0.0, 0.0, 1.0));
-
-        glm::mat4 rotationMatrix = rotationZMatrix * rotationYMatrix * rotationXMatrix;
+		glm::mat4 rotationMatrix = glm::toMat4(quaternion); // Construct a matrix from the quaternion vector.
 
         glm::mat4 scaleMatrix = glm::mat4(1.0);
         scaleMatrix = glm::scale(scaleMatrix, glm::vec3(scale.x, scale.y, scale.z));


### PR DESCRIPTION
Changes in **Transform.h** class header to accommodate quaternion based rotations instead of Euler rotations to avoid Gimbal locks.

